### PR TITLE
Use a static message template for a Log.Error() call

### DIFF
--- a/baseline/Simple.Serilog/Middleware/ApiExceptionMiddleware.cs
+++ b/baseline/Simple.Serilog/Middleware/ApiExceptionMiddleware.cs
@@ -41,7 +41,7 @@ namespace Simple.Serilog.Middleware
 
             opts.AddResponseDetails?.Invoke(context, exception, error);
 
-            Log.Error(exception, exception.Message);
+            Log.Error(exception, "An exception was caught in the API request pipeline");
 
             var result = JsonConvert.SerializeObject(error);
             context.Response.ContentType = "application/json";


### PR DESCRIPTION
Minor tweak to consider :-)

 - The exception message won't necessarily be valid as a [message template](https://messagetemplates.org) (might have unescaped `{`s), and using it there will thwart the efforts of sinks/pipelines that treat the message template as an [event type](https://nblumhardt.com/2015/10/assigning-event-types-to-serilog-events/)
 - Most Serilog sinks will end up duplicating the exception message in output, via the exception object and via the message template, so using the message to give context about where the exception's being handled  can provide a bit more bang-for-the-buck